### PR TITLE
feat: after login processing (success, failure)

### DIFF
--- a/src/main/java/dev/smjeon/commerce/oauth/common/presentation/SocialLoginController.java
+++ b/src/main/java/dev/smjeon/commerce/oauth/common/presentation/SocialLoginController.java
@@ -18,7 +18,7 @@ public class SocialLoginController {
         this.githubLoginService = githubLoginService;
     }
 
-    @GetMapping("/login/{socialProvider}")
+    @GetMapping("/login/social/{socialProvider}")
     public RedirectView loginWithSocial(@PathVariable SocialProviders socialProvider) {
         if (SocialProviders.KAKAO.equals(socialProvider)) {
             return new RedirectView(kakaoLoginService.getRedirectUrl());

--- a/src/main/java/dev/smjeon/commerce/security/config/SecurityConfig.java
+++ b/src/main/java/dev/smjeon/commerce/security/config/SecurityConfig.java
@@ -89,7 +89,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
         http
                 .authorizeRequests()
                 .antMatchers("/api/users").hasRole(UserRole.ADMIN.name())
-                .antMatchers("/", "/api/users/signup", "/login/**", "/signup").permitAll()
+                .antMatchers("/", "/api/users/signup", "/login/**", "/login*", "/signup").permitAll()
                 .antMatchers("/api/products/**").permitAll()
                 .anyRequest().authenticated()
                 .and()

--- a/src/main/java/dev/smjeon/commerce/security/config/SecurityConfig.java
+++ b/src/main/java/dev/smjeon/commerce/security/config/SecurityConfig.java
@@ -90,6 +90,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                 .authorizeRequests()
                 .antMatchers("/api/users").hasRole(UserRole.ADMIN.name())
                 .antMatchers("/", "/api/users/signup", "/login/**", "/login*", "/signup").permitAll()
+                .antMatchers("/api/categories").permitAll()
                 .antMatchers("/api/products/**").permitAll()
                 .anyRequest().authenticated()
                 .and()

--- a/src/main/java/dev/smjeon/commerce/security/exception/UnauthorizedException.java
+++ b/src/main/java/dev/smjeon/commerce/security/exception/UnauthorizedException.java
@@ -2,8 +2,9 @@ package dev.smjeon.commerce.security.exception;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.security.authentication.BadCredentialsException;
 
-public class UnauthorizedException extends RuntimeException {
+public class UnauthorizedException extends BadCredentialsException {
     private static final Logger logger = LoggerFactory.getLogger(UnauthorizedException.class);
     private static final String MESSAGE = "인증 실패.";
 

--- a/src/main/java/dev/smjeon/commerce/security/handlers/FormLoginAuthenticationFailureHandler.java
+++ b/src/main/java/dev/smjeon/commerce/security/handlers/FormLoginAuthenticationFailureHandler.java
@@ -1,9 +1,10 @@
 package dev.smjeon.commerce.security.handlers;
 
+import dev.smjeon.commerce.security.exception.UnauthorizedException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.security.core.AuthenticationException;
-import org.springframework.security.web.authentication.AuthenticationFailureHandler;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationFailureHandler;
 import org.springframework.stereotype.Component;
 
 import javax.servlet.ServletException;
@@ -12,13 +13,23 @@ import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 
 @Component
-public class FormLoginAuthenticationFailureHandler implements AuthenticationFailureHandler {
+public class FormLoginAuthenticationFailureHandler extends SimpleUrlAuthenticationFailureHandler {
     private static final Logger logger = LoggerFactory.getLogger(FormLoginAuthenticationFailureHandler.class);
+
+    private static final String ERROR_MESSAGE = "Invalid Email or Password";
 
     @Override
     public void onAuthenticationFailure(HttpServletRequest req, HttpServletResponse res, AuthenticationException exception)
             throws IOException, ServletException {
+        String errorMessage = ERROR_MESSAGE;
+
+        if (exception instanceof UnauthorizedException) {
+            errorMessage = ERROR_MESSAGE;
+        }
+
+        setDefaultFailureUrl("/login?error=true&exception=" + errorMessage);
         logger.debug("Authentication failure");
-        res.sendRedirect("/login");
+
+        super.onAuthenticationFailure(req, res, exception);
     }
 }

--- a/src/main/java/dev/smjeon/commerce/user/presentation/UserController.java
+++ b/src/main/java/dev/smjeon/commerce/user/presentation/UserController.java
@@ -2,13 +2,21 @@ package dev.smjeon.commerce.user.presentation;
 
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.servlet.ModelAndView;
 
 @Controller
 public class UserController {
 
     @GetMapping("/login")
-    public String showLoginPage() {
-        return "login";
+    public ModelAndView showLoginPage(@RequestParam(value = "error", required = false) String error,
+                                      @RequestParam(value = "exception", required = false) String exception,
+                                      ModelAndView mav) {
+        mav.addObject("error", error);
+        mav.addObject("exception", exception);
+        mav.setViewName("login");
+
+        return mav;
     }
 
     @GetMapping("/signup")

--- a/src/main/resources/templates/login.html
+++ b/src/main/resources/templates/login.html
@@ -53,11 +53,11 @@
                     <hr class="login-separator">
                     <a href="/signup" class="signin-button">회원가입</a>
                     <hr class="login-separator">
-                    <a href="/login/github"><img src="images/github_login.png" alt="github_login"
-                                                 class="social-login-button"></a>
+                    <a href="/login/social/github"><img src="images/github_login.png" alt="github_login"
+                                                        class="social-login-button"></a>
                     <hr class="login-separator">
-                    <a href="/login/kakao"><img src="images/kakao_login.png" alt="kakao_login"
-                                                class="social-login-button"></a>
+                    <a href="/login/social/kakao"><img src="images/kakao_login.png" alt="kakao_login"
+                                                       class="social-login-button"></a>
                 </div>
             </div>
         </form>

--- a/src/main/resources/templates/login.html
+++ b/src/main/resources/templates/login.html
@@ -2,6 +2,7 @@
 <html lang="en" xmlns:th="http://www.thymeleaf.org">
 <head>
     <meta charset="UTF-8">
+    <link href="/css/bootstrap.min.css" rel="stylesheet">
     <link rel="stylesheet" href="/css/login.css">
     <title>로그인</title>
 </head>
@@ -15,6 +16,9 @@
                 </a>
             </h1>
         </header>
+        <div th:if="${param.error}" class="form-group">
+            <span th:text="${param.exception}" class="alert alert-danger"></span>
+        </div>
         <form class="login-form" method="post" th:action="@{/api/users/signin}">
             <div id="login_content">
                 <label class="login-wrap" for="login-email-input">

--- a/src/test/java/dev/smjeon/commerce/common/TestTemplate.java
+++ b/src/test/java/dev/smjeon/commerce/common/TestTemplate.java
@@ -19,8 +19,9 @@ import java.util.Objects;
 
 @AutoConfigureWebTestClient
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
-        properties = {"spring.config.location=classpath:oauth.yml",
-                "spring.config.location=classpath:application.yml"})
+        properties = "spring.config.location=" +
+                "classpath:oauth.yml," +
+                "classpath:application.yml")
 public class TestTemplate {
 
     @Autowired

--- a/src/test/java/dev/smjeon/commerce/oauth/common/presentation/SocialLoginControllerTest.java
+++ b/src/test/java/dev/smjeon/commerce/oauth/common/presentation/SocialLoginControllerTest.java
@@ -11,7 +11,7 @@ class SocialLoginControllerTest extends TestTemplate {
     @Test
     @DisplayName("kakao 로그인 시 해당 url로 redirect됩니다.")
     void kakaoLoginRedirect() {
-        request(HttpMethod.GET, "/login/kakao", Void.class, HttpStatus.FOUND)
+        request(HttpMethod.GET, "/login/social/kakao", Void.class, HttpStatus.FOUND)
                 .expectHeader()
                 .value("Location", Matchers.containsString("/oauth/kakao"));
     }
@@ -19,7 +19,7 @@ class SocialLoginControllerTest extends TestTemplate {
     @Test
     @DisplayName("github 로그인 시 해당 url로 redirect됩니다.")
     void githubLoginRedirect() {
-        request(HttpMethod.GET, "/login/github", Void.class, HttpStatus.FOUND)
+        request(HttpMethod.GET, "/login/social/github", Void.class, HttpStatus.FOUND)
                 .expectHeader()
                 .value("Location", Matchers.containsString("/oauth/github"));
     }

--- a/src/test/java/dev/smjeon/commerce/user/presentation/UserApiControllerTest.java
+++ b/src/test/java/dev/smjeon/commerce/user/presentation/UserApiControllerTest.java
@@ -5,6 +5,7 @@ import dev.smjeon.commerce.user.domain.Email;
 import dev.smjeon.commerce.user.domain.NickName;
 import dev.smjeon.commerce.user.domain.Password;
 import dev.smjeon.commerce.user.dto.UserSignUpRequest;
+import org.hamcrest.Matchers;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpMethod;
@@ -30,9 +31,11 @@ public class UserApiControllerTest extends TestTemplate {
     }
 
     @Test
-    @DisplayName("권한 없이 유저리스트를 요청하면 거절됩니다.")
+    @DisplayName("권한 없이 유저리스트를 요청하면 로그인 페이지로 리다이렉트 됩니다.")
     void showUsersWithoutAuth() {
-        respondApi(request(HttpMethod.GET, "/api/users", Void.class, HttpStatus.FORBIDDEN));
+        request(HttpMethod.GET, "/api/users", Void.class, HttpStatus.FOUND)
+                .expectHeader()
+                .value("Location", Matchers.containsString("/login"));
     }
 
     @Test


### PR DESCRIPTION
로그인 성공, 실패 이후 처리

로그인 성공 시 - 이전에 가려고 했던 페이지로 리다이렉트(default: /)
로그인 실패 시 - 로그인 실패 이유를 프론트에 뿌려주기(redirect: /login + params)

fix: #62 